### PR TITLE
POW-68 nullと表示される場合がある

### DIFF
--- a/functions/crawler/Mountain.js
+++ b/functions/crawler/Mountain.js
@@ -39,7 +39,7 @@ export class Mountain {
           },
           {
             type: 'text',
-            text: `更新日: ${this.updated}`,
+            text: `更新日: ${this.updated || '-'}`,
             size: 'xs',
             color: '#aaaaaa',
             wrap: true,
@@ -83,7 +83,7 @@ export class Mountain {
                   },
                   {
                     type: 'text',
-                    text: `${this.depth} cm`,
+                    text: `${this.depth || '-'} cm`,
                     size: 'sm',
                     color: '#111111',
                     align: 'end',
@@ -103,7 +103,7 @@ export class Mountain {
                   },
                   {
                     type: 'text',
-                    text: `${this.temperature} ℃`,
+                    text: `${this.temperature || '-'} ℃`,
                     size: 'sm',
                     color: '#111111',
                     align: 'end',


### PR DESCRIPTION
斑尾に限らず、更新日、積雪量、気温がnullの場合
nullと表示されてしまっていたが
`-`と表示するように変更
#68 